### PR TITLE
docs: Add CI workflow badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Espargne - Retirement Planning Application
 
+[![CI](https://github.com/frouaix/espargne-web/actions/workflows/ci.yml/badge.svg)](https://github.com/frouaix/espargne-web/actions/workflows/ci.yml)
 [![Deploy to GitHub Pages](https://github.com/frouaix/espargne-web/actions/workflows/deploy.yml/badge.svg)](https://github.com/frouaix/espargne-web/actions/workflows/deploy.yml)
 
 A pure TypeScript SPA for US retirement planning with comprehensive financial simulations. All calculations run in the browser with no backend required.


### PR DESCRIPTION
Testing the refactored CI workflow after GitHub configuration fix.

This PR adds a CI badge to the README to show build status.